### PR TITLE
The project originally had a dependency on http-client 0.1.7 but a chang...

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [puppetlabs/http-client "0.1.7"]
+                 [puppetlabs/http-client "0.2.0"]
                  [prismatic/schema "0.2.4"]
                  [com.cemerick/url "0.1.1"]
                  [cheshire "5.3.1"]])

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -38,9 +38,8 @@
   ([client :- Client ^String path]
      #_(println "GET:" path) ;; uncomment this to watch queries
      (let [{:keys [host opts]} client]
-       (-> (http/get (str host path) opts)
+       (-> (http/get (str host path) (assoc opts :as :text))
            :body
-           slurp
            (json/decode keyword))))
   ([client path params]
      (let [query-params (map->query params)

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -40,6 +40,7 @@
      (let [{:keys [host opts]} client]
        (-> (http/get (str host path) opts)
            :body
+           slurp
            (json/decode keyword))))
   ([client path params]
      (let [query-params (map->query params)


### PR DESCRIPTION
...e in 0.2.0 and later means the :body is a stream rather than a string. That causes problems if you try to use the library in another project with a dependency on 0.2.0 or later that. I've upversioned to 0.2.0 only rather than implying a depend on any later version of http-client.

This commit just grabs the whole contents of the stream. There's probably scope for better laziness here.
